### PR TITLE
feat: add several user commands

### DIFF
--- a/command.go
+++ b/command.go
@@ -21,18 +21,32 @@ type Command uint8
 
 // Command Number Assignments (table G-1)
 const (
-	CommandGetDeviceID              = Command(0x01)
-	CommandGetAuthCapabilities      = Command(0x38)
+	// Session Commands
 	CommandGetSessionChallenge      = Command(0x39)
 	CommandActivateSession          = Command(0x3a)
 	CommandSetSessionPrivilegeLevel = Command(0x3b)
 	CommandCloseSession             = Command(0x3c)
-	CommandChassisControl           = Command(0x02)
-	CommandChassisStatus            = Command(0x01)
-	CommandSetSystemBootOptions     = Command(0x08)
-	CommandGetSystemBootOptions     = Command(0x09)
-	CommandSetUserName              = Command(0x45)
-	CommandGetUserName              = Command(0x46)
+
+	// Chassis Commands
+	CommandChassisControl = Command(0x02)
+	CommandChassisStatus  = Command(0x01)
+
+	// Boot Commands
+	CommandSetSystemBootOptions = Command(0x08)
+	CommandGetSystemBootOptions = Command(0x09)
+
+	// User Commands
+	CommandSetUserAccess  = Command(0x43)
+	CommandSetUserName    = Command(0x45)
+	CommandGetUserName    = Command(0x46)
+	CommandGetUserSummary = Command(0x44)
+	CommandSetUserPass    = Command(0x47)
+	CommandEnableUser     = Command(0x47)
+
+	// Misc
+	CommandGetDeviceID         = Command(0x01)
+	CommandGetLANConfig        = Command(0x02)
+	CommandGetAuthCapabilities = Command(0x38)
 )
 
 // Request structure

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/pensando/goipmi
 
+go 1.15
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/lan.go
+++ b/lan.go
@@ -28,6 +28,39 @@ import (
 	"time"
 )
 
+type LANConfigRequest struct {
+	ChannelNumber uint8
+	Param         uint8
+	Set           uint8
+	Block         uint8
+}
+
+type LANConfigResponse struct {
+	CompletionCode
+	Param uint8
+	Data  []uint8
+}
+
+// MarshalBinary implementation to handle variable length Data
+func (r *LANConfigResponse) MarshalBinary() ([]byte, error) {
+	buf := make([]byte, 2+len(r.Data))
+	buf[0] = byte(r.CompletionCode)
+	buf[1] = r.Param
+	copy(buf[2:], r.Data)
+	return buf, nil
+}
+
+// UnmarshalBinary implementation to handle variable length Data
+func (r *LANConfigResponse) UnmarshalBinary(buf []byte) error {
+	if len(buf) < 2 {
+		return ErrShortPacket
+	}
+	r.CompletionCode = CompletionCode(buf[0])
+	r.Param = buf[1]
+	r.Data = buf[2:]
+	return nil
+}
+
 type lan struct {
 	*Connection
 	ipmiSession

--- a/message.go
+++ b/message.go
@@ -45,8 +45,9 @@ type NetworkFunction uint8
 
 // Network Function Codes per section 5.1
 var (
-	NetworkFunctionChassis = NetworkFunction(0x00)
-	NetworkFunctionApp     = NetworkFunction(0x06)
+	NetworkFunctionChassis   = NetworkFunction(0x00)
+	NetworkFunctionApp       = NetworkFunction(0x06)
+	NetworkFunctionTransport = NetworkFunction(0x0c)
 )
 
 var (

--- a/transport.go
+++ b/transport.go
@@ -35,6 +35,8 @@ func newTransport(c *Connection) (transport, error) {
 		return newToolTransport(c), nil
 	case "lanplus":
 		return newToolTransport(c), nil
+	case "open":
+		return newToolTransport(c), nil
 	default:
 		return nil, fmt.Errorf("unsupported interface: %s", c.Interface)
 	}


### PR DESCRIPTION
This PR adds the following commands:

- Get LAN Config
- Get User Summary
- Set User Pass
- Set User Access
- Enable User

It also adds support for "open" as an interface, as that seems to be
required for local requests in my environment.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>